### PR TITLE
Add missing navigation items for digital payments and purchasing

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,14 @@
             <span class="material-symbols-outlined">account_tree</span>
             <span class="nav-text">Alokasi Anggaran</span>
         </button>
+        <button class="nav-item" data-nav="pembayaran-digital" data-role="Editor,Owner">
+          <span class="material-symbols-outlined">payments</span>
+          <span class="nav-text">Pembayaran Digital</span>
+        </button>
+        <button class="nav-item" data-nav="pembelian" data-role="Editor,Owner">
+          <span class="material-symbols-outlined">shopping_cart</span>
+          <span class="nav-text">Pembelian</span>
+        </button>
         <button class="nav-item" data-nav="input-data" data-role="Editor,Owner">
           <span class="material-symbols-outlined">post_add</span>
           <span class="nav-text">Input Pengeluaran</span>

--- a/script.js
+++ b/script.js
@@ -149,6 +149,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const digitalEnvelopesDoc = doc(db, 'teams', TEAM_ID, 'envelopes', 'main_budget');
     const notificationsCol = collection(db, 'teams', TEAM_ID, 'notifications');
 
+    const NAV_PAGES = [
+        { id: 'dashboard', name: 'Dashboard' },
+        { id: 'pemasukan-pinjaman', name: 'Pemasukan & Pinjaman' },
+        { id: 'alokasi-anggaran', name: 'Alokasi Anggaran' },
+        { id: 'pembayaran-digital', name: 'Pembayaran Digital' },
+        { id: 'pembelian', name: 'Pembelian' },
+        { id: 'input-data', name: 'Input Pengeluaran' },
+        { id: 'absensi', name: 'Absensi' },
+        { id: 'manajemen-stok', name: 'Manajemen Stok' },
+        { id: 'tagihan', name: 'Tagihan' },
+        { id: 'laporan', name: 'Laporan' },
+        { id: 'pengaturan', name: 'Pengaturan' },
+    ];
+
     // ===== Sistem Toast & Modal (Refactored) =====
     let popupTimeout;
     function toast(kind, text, duration = 3200) {
@@ -461,11 +475,13 @@ document.addEventListener('DOMContentLoaded', () => {
             'dashboard': renderDashboardPage,
             'pemasukan-pinjaman': renderPemasukanPage, 
             'alokasi-anggaran': renderAlokasiPage,
-            'input-data': renderInputDataPage, 
-            'pengaturan': renderPengaturanPage, 
+            'pembayaran-digital': renderPembayaranDigitalPage,
+            'pembelian': renderPembelianPage,
+            'input-data': renderInputDataPage,
+            'pengaturan': renderPengaturanPage,
             'tagihan': renderTagihanPage,
-            'laporan': renderLaporanPage, 
-            'absensi': renderAbsensiPage, 
+            'laporan': renderLaporanPage,
+            'absensi': renderAbsensiPage,
             'manajemen-stok': renderManajemenStokPage,
         };
         const renderer = pageRenderers[appState.activePage];
@@ -1964,7 +1980,15 @@ document.addEventListener('DOMContentLoaded', () => {
             console.error("Stock usage error:", error);
         }
     }
-    
+
+    async function renderPembayaranDigitalPage(container) {
+        container.innerHTML = `<div class="card card-pad">Halaman Pembayaran Digital dalam pengembangan.</div>`;
+    }
+
+    async function renderPembelianPage(container) {
+        container.innerHTML = `<div class="card card-pad">Halaman Pembelian dalam pengembangan.</div>`;
+    }
+
     async function renderAlokasiPage(container) {
         const envelopes = appState.digitalEnvelopes;
         container.innerHTML = `
@@ -2209,19 +2233,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function handleGlobalSearch(e) {
         const searchTerm = e.target.value.toLowerCase();
         const resultsContainer = $('#search-results');
-        const navItems = [
-            { id: 'dashboard', name: 'Dashboard' },
-            { id: 'pemasukan-pinjaman', name: 'Pemasukan & Pinjaman' },
-            { id: 'alokasi-anggaran', name: 'Alokasi Anggaran' },
-            { id: 'input-data', name: 'Input Pengeluaran' },
-            { id: 'absensi', name: 'Absensi Pekerja' },
-            { id: 'tagihan', name: 'Manajemen Tagihan' },
-            { id: 'manajemen-stok', name: 'Manajemen Stok' },
-            { id: 'laporan', name: 'Laporan Keuangan' },
-            { id: 'pengaturan', name: 'Pengaturan' },
-        ];
-
-        const filteredItems = navItems.filter(item => item.name.toLowerCase().includes(searchTerm));
+        const filteredItems = NAV_PAGES.filter(item => item.name.toLowerCase().includes(searchTerm));
         
         if (filteredItems.length > 0) {
             resultsContainer.innerHTML = filteredItems.map(item => 
@@ -2254,8 +2266,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function injectPageTemplates() {
         const container = $('.page-container');
         if (!container || container.childElementCount > 0) return;
-        const pages = ['dashboard', 'pemasukan-pinjaman', 'alokasi-anggaran', 'input-data', 'absensi', 'tagihan', 'manajemen-stok', 'laporan', 'pengaturan'];
-        container.innerHTML = pages.map(id => `<main id="page-${id}" class="page"></main>`).join('');
+        container.innerHTML = NAV_PAGES.map(p => `<main id="page-${p.id}" class="page"></main>`).join('');
     }
 
     init();


### PR DESCRIPTION
## Summary
- Add "Pembayaran Digital" and "Pembelian" buttons to sidebar navigation with authorization roles
- Extend router to recognize new page IDs and provide placeholder renderers
- Include new pages in search and template injection lists
- Centralize navigation page metadata for consistent search and template injection

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/BanPlex/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c70725be14832aaaa421d93fa66a87